### PR TITLE
Fixing standalone tests to be async

### DIFF
--- a/standalone-mode/test/e2e/first.js
+++ b/standalone-mode/test/e2e/first.js
@@ -5,7 +5,7 @@ module.exports = () => {
 
   describe('First Test Group', () => {
     it('gets the title of MDN toppage', () => {
-      browser
+      return browser
         .url('https://developer.mozilla.org/en-US/')
         .getTitle().then(title => {
            assert.equal(title, 'Mozilla Developer Network')

--- a/standalone-mode/test/e2e/second.js
+++ b/standalone-mode/test/e2e/second.js
@@ -5,7 +5,7 @@ module.exports = () => {
 
   describe('Second Test Group', () => {
     it('gets the title of GitHub toppage', () => {
-      browser
+      return browser
         .url('https://github.com/')
         .getTitle().then(title => {
            assert.equal(title, 'How people build software · GitHub')


### PR DESCRIPTION
Without this, the standalone tests aren't asserting anything. They pass regardless of whether or not the assertion fails
